### PR TITLE
Enable usb typec

### DIFF
--- a/androidia_64/init.rc
+++ b/androidia_64/init.rc
@@ -10,9 +10,6 @@ on fs
     mount_all /fstab.${ro.hardware}
     mkdir /dev/pstore 0755 root system
     mount pstore pstore /dev/pstore
-    mkdir /dev/usb-ffs 0770 shell shell
-    mkdir /dev/usb-ffs/adb 0770 shell shell
-    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
 
 on post-fs
     setprop ro.setupwizard.mode DISABLED
@@ -35,17 +32,6 @@ on boot
 
     setprop persist.sys.strictmode.visual 0
     setprop persist.sys.strictmode.disable 1
-
-    # USB Gadget initialization
-    write /sys/class/android_usb/android0/enable 0
-    write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
-    write /sys/class/android_usb/android0/iProduct ${ro.product.model}
-    write /sys/class/android_usb/android0/iSerial ${ro.serialno}
-    write /sys/class/android_usb/android0/f_ffs/aliases adb
-    write /sys/class/android_usb/android0/functions adb
-    write /sys/class/android_usb/android0/idVendor 8087
-    write /sys/class/android_usb/android0/idProduct 09ef
-    write /sys/class/android_usb/android0/enable 1
 
     chmod 0660 /sys/class/tty/ttyHSU1/../../power/control
     chown system system /sys/class/tty/ttyHSU1/../../power/control
@@ -162,6 +148,46 @@ on init
     symlink /sdcard /mnt/sdcard
     symlink /sdcard /storage/sdcard0
 
+##############################################################
+# Source: device/intel/mixins/groups/usb-gadget/g_ffs/init.rc
+##############################################################
+on fs
+    write /sys/class/android_usb/android0/f_ffs/aliases adb
+    write /sys/class/android_usb/android0/iSerial ${ro.serialno}
+
+on boot
+    # Create mount-point for ConfigFS USB gadgets
+    # Add standard gadget entries
+    mount configfs none /config
+    mkdir /config/usb_gadget/g1 0770 shell shell
+    write /config/usb_gadget/g1/idVendor 0x18d1
+    mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell
+    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
+    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
+    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
+    mkdir /config/usb_gadget/g1/functions/ffs.adb 0770 shell shell
+    mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
+    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
+    write /config/usb_gadget/g1/configs/b.1/MaxPower 500
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
+
+    # Create adb+ffs gadget function
+    mkdir /dev/usb-ffs 0770 shell shell
+    mkdir /dev/usb-ffs/adb 0770 shell shell
+    mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
+
+    # Enable USB Gadget Configfs interface and make DWC3 the controller
+    setprop sys.usb.configfs 1
+    setprop sys.usb.controller dwc3.0.auto
+    write /config/usb_gadget/g1/UDC dwc3.0.auto
+    chmod 0666 /dev/sw_sync
+
+on property:sys.usb.config=none && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/os_desc/use 0
+    setprop sys.usb.ffs.ready 0
+
+on property:init.svc.adbd=stopped
+    setprop sys.usb.ffs.ready 0
 ##############################################################
 # Source: device/intel/mixins/groups/adb_net/true/init.rc
 ##############################################################

--- a/androidia_64/mixins.spec
+++ b/androidia_64/mixins.spec
@@ -14,6 +14,7 @@ ethernet: dhcp
 debugfs: default
 storage: default
 display-density: default
+usb-gadget: g_ffs
 adb_net: true
 kernel: android_ia
 bluetooth: btusb


### PR DESCRIPTION
Changes in the init.rc and mixins group to enable usb type c support