### PR TITLE
Enable built-in mic.

### DIFF
--- a/common/audio/mixer_paths.xml
+++ b/common/audio/mixer_paths.xml
@@ -193,6 +193,8 @@
     <ctl name="HDMI Mixer MultiMedia4" value="0" />
     <ctl name="Master Playback Volume" value="100" />
     <ctl name="Master Playback Switch" value="100" />
+    <ctl name="Capture Switch" value="1" />
+    <ctl name="Capture Volume" value="63" />
     <!-- echo reference -->
     <ctl name="AUDIO_REF_EC_UL1 MUX" value="None" />
     <!-- usb headset -->


### PR DESCRIPTION
After boot, the built-in mic doesn't work, because it's not enabled in
the mixer settings. One needs to set:
- Capture Switch => 1
- Capture Volume => non-zero (63 in my case)

Jira: https://01.org/jira/browse/AIA-228
Test: mic is working after boot

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>