### PR TITLE
Remove mobile type from network attributes

### DIFF
--- a/common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -31,14 +31,7 @@
     <!-- the 6th element indicates boot-time dependency-met value. -->
     <string-array translatable="false" name="networkAttributes">
         <item>"wifi,1,1,1,-1,true"</item>
-        <item>"mobile,0,0,0,-1,true"</item>
-        <item>"mobile_mms,2,0,2,60000,true"</item>
-        <item>"mobile_supl,3,0,2,60000,true"</item>
-        <item>"mobile_hipri,5,0,3,60000,true"</item>
         <item>"ethernet,9,9,1,-1,true"</item>
-        <item>"mobile_fota,10,0,2,60000,true"</item>
-        <item>"mobile_ims,11,0,2,60000,true"</item>
-        <item>"mobile_cbs,12,0,2,60000,true"</item>
         <item>"wifi_p2p,13,1,0,-1,true"</item>
     </string-array>
 
@@ -49,7 +42,6 @@
                                [# simultaneous connection types]"  -->
     <string-array translatable="false" name="radioAttributes">
         <item>"1,1"</item>
-        <item>"0,1"</item>
         <item>"9,1"</item>
     </string-array>
 


### PR DESCRIPTION
Change is done to enable only wifi and ethernet network types.
networkAttributes can be overrided as per device type
in device specific overlays.

Jira: https://01.org/jira/browse/AIA-331

Tests: Boot, Wifi enable/disable

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>