### PR TITLE
MIXIN: Enable the factory partition

### DIFF
--- a/androidia_64/mixins.spec
+++ b/androidia_64/mixins.spec
@@ -30,6 +30,7 @@ usb: host+acc
 lights: true
 config-partition: enabled
 vendor-partition: true(partition_size=1500,partition_name=android_vendor)
+factory-partition: true
 debug-crashlogd: true
 debug-logs: true
 debug-phonedoctor: true


### PR DESCRIPTION
Enable the factory partition in Android_IA build

The Contents to be part of factory.img is not yet updated
    and the img generated is an empty image

Jira :  AIA-397
Test :  The build should generate a factory.img
	The CI test bench flashing should work

Change-Id: I64d66e4ffe61657f900e928c8f1ce555ea8e47f8
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>