### PR TITLE
Enabling Miracast on AIA

### DIFF
--- a/common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -67,4 +67,19 @@
     <!-- When true use the linux /dev/input/event subsystem to detect the switch changes
          on the headphone/microphone jack. When false use the older uevent framework. -->
     <bool name="config_useDevInputEventForAudioJack">true</bool>
+
+    <!-- Whether WiFi display is supported by this device.
+         There are many prerequisites for this feature to work correctly.
+         Here are a few of them:
+         * The WiFi radio must support WiFi P2P.
+         * The WiFi radio must support concurrent connections to the WiFi display and
+           to an access point.
+         * The Audio Flinger audio_policy.conf file must specify a rule for the "r_submix"
+           remote submix module.  This module is used to record and stream system
+           audio output to the WiFi display encoder in the media server.
+         * The remote submix module "audio.r_submix.default" must be installed on the device.
+         * The device must be provisioned with HDCP keys (for protected content).
+    -->
+    <bool name="config_enableWifiDisplay">true</bool>
+    
 </resources>


### PR DESCRIPTION
Enabling Miracst option from UI

Jira: https://01.org/jira/browse/AIA-246

Test:
    Under Setting-> Display-> Cast, the checkbox - "Enable wireless display" should be present.
    On selecting the checkbox, list of peers available for wireless display should get listed.

Signed-off-by: Amrita Raju

 @Kishore409 @kalyankondapally 