### PR TITLE
Add support for stub HAL

### DIFF
--- a/androidia_64/BoardConfig.mk
+++ b/androidia_64/BoardConfig.mk
@@ -165,10 +165,15 @@ TARGET_RECOVERY_PIXEL_FORMAT := "BGRA_8888"
 BOARD_USES_ALSA_AUDIO := true
 BOARD_USES_TINY_ALSA_AUDIO := true
 BOARD_USES_GENERIC_AUDIO ?= false
+ifneq ($(BOARD_USES_GENERIC_AUDIO), true)
 # Audio HAL selection Flag default setting.
 #  INTEL_AUDIO_HAL:= audio     -> baseline HAL
 #  INTEL_AUDIO_HAL:= audio_pfw -> PFW-based HAL
 INTEL_AUDIO_HAL := audio
+else
+INTEL_AUDIO_HAL := stub
+endif
+
 # Use XML audio policy configuration file
 USE_XML_AUDIO_POLICY_CONF ?= 1
 # Use configurable audio policy

--- a/androidia_64/device.mk
+++ b/androidia_64/device.mk
@@ -330,9 +330,16 @@ PRODUCT_PACKAGES_DEBUG += \
          tinyplay \
          tinycap
 
+ifneq ($(BOARD_USES_GENERIC_AUDIO), true)
+PRODUCT_PACKAGES += \
+    audio.primary.android_ia
+else
+PRODUCT_PACKAGES += \
+    audio.primary.default
+endif
+
 # Extended Audio HALs
 PRODUCT_PACKAGES += \
-    audio.primary.android_ia \
     audio.r_submix.default \
     audio.usb.default \
     audio_policy.default.so \

--- a/common/audio/AndroidBoard.mk
+++ b/common/audio/AndroidBoard.mk
@@ -1,6 +1,15 @@
 LOCAL_PATH := $(call my-dir)
 
 # audio hardware is not discoverable, select hardware or use basic default
+ifeq ($(INTEL_AUDIO_HAL), stub)
+
+# this option only enables USB, A2DP and remote submix audio.
+# the audio.primary.default HAL is part of the build to pass
+# CTS tests but only acts as a NULL sink/source
+
+AUDIO_HARDWARE := stub
+
+else
 AUDIO_HARDWARE := default
 #AUDIO_HARDWARE := PCH-CX20724
 # Next configuration is used for Intel NUC6i5SYH

--- a/common/audio/stub/mixer_paths_0.xml
+++ b/common/audio/stub/mixer_paths_0.xml
@@ -1,0 +1,3 @@
+<mixer>
+  <!-- Dummy file in case of stub HAL -->
+</mixer>

--- a/common/audio/stub/policy/audio_policy_configuration.xml
+++ b/common/audio/stub/policy/audio_policy_configuration.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Copyright (C) 2017 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<audioPolicyConfiguration version="1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <!-- version section contains a “version” tag in the form “major.minor” e.g version=”1.0” -->
+
+    <!-- Modules section:
+        There is one section per audio HW module present on the platform.
+        Each module section will contains two mandatory tags for audio HAL “halVersion” and “name”.
+        The module names are the same as in current .conf file:
+                “primary”, “A2DP”, “remote_submix”, “USB”
+        Each module will contain the following sections:
+        “devicePorts”: a list of device descriptors for all input and output devices accessible via this
+        module.
+        This contains both permanently attached devices and removable devices.
+        “mixPorts”: listing all output and input streams exposed by the audio HAL
+        “routes”: list of possible connections between input and output devices or between stream and
+        devices.
+            "route": is defined by an attribute:
+                -"type": <mux|mix> means all sources are mutual exclusive (mux) or can be mixed (mix)
+                -"sink": the sink involved in this route
+                -"sources": all the sources than can be connected to the sink via vis route
+        “attachedDevices”: permanently attached devices.
+        The attachedDevices section is a list of devices names. The names correspond to device names
+        defined in <devicePorts> section.
+        “defaultOutputDevice”: device to be used by default when no policy rule applies
+    -->
+    <modules>
+
+        <!-- Stub Audio HAL -->
+        <xi:include href="stub_audio_policy_configuration.xml"/>
+
+        <!-- A2dp Audio HAL -->
+        <xi:include href="a2dp_audio_policy_configuration.xml"/>
+
+        <!-- Usb Audio HAL -->
+        <xi:include href="usb_audio_policy_configuration.xml"/>
+
+        <!-- Remote Submix Audio HAL -->
+        <xi:include href="r_submix_audio_policy_configuration.xml"/>
+
+    </modules>
+    <!-- End of Modules section -->
+
+    <!-- Volume section -->
+
+    <xi:include href="audio_policy_volumes.xml"/>
+    <xi:include href="default_volume_tables.xml"/>
+
+    <!-- End of Volume section -->
+
+</audioPolicyConfiguration>


### PR DESCRIPTION
This is required for Joule support or any device
with no attached audio hardware

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-44350
Test: make sure audio apps work (no sound of course) and that USB audio
is detected and takes over

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>