### PR TITLE
Configuration files for PFW-based HAL

### DIFF
--- a/common/audio/PCH-CX20724/AndroidBoard.mk
+++ b/common/audio/PCH-CX20724/AndroidBoard.mk
@@ -1,0 +1,89 @@
+LOCAL_PATH := $(call my-dir)
+PFW_CORE := external/parameter-framework
+BUILD_PFW_SETTINGS := $(PFW_CORE)/support/android/build_pfw_settings.mk
+PFW_DEFAULT_SCHEMAS_DIR := $(PFW_CORE)/upstream/schemas
+PFW_SCHEMAS_DIR := $(PFW_DEFAULT_SCHEMAS_DIR)
+
+###########################################
+# Audio stack Package
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := audio_parameter_framework
+LOCAL_MODULE_TAGS := optional
+LOCAL_REQUIRED_MODULES := \
+    libremote-processor \
+    remote-process \
+    AudioConfigurableDomains.xml
+
+include $(BUILD_PHONY_PACKAGE)
+
+###########################################
+# Audio PFW Package
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioConfigurableDomains.xml
+LOCAL_MODULES_TAGS := optional
+LOCAL_ADDITIONAL_DEPENDENCIES := \
+    AudioParameterFramework.xml \
+    AudioClass.xml \
+    ConexantCX20724Subsystem.xml \
+    HdmiSubsystem.xml
+
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Settings/Audio
+LOCAL_REQUIRED_MODULES := \
+    libtinyalsa-subsystem
+
+PFW_TOPLEVEL_FILE := $(TARGET_OUT_ETC)/parameter-framework/AudioParameterFramework.xml
+PFW_CRITERIA_FILE := $(LOCAL_PATH)/parameter-framework/AudioCriteria.txt
+PFW_TUNING_FILE   := $(LOCAL_PATH)/$(LOCAL_MODULE_RELATIVE_PATH)/AudioConfigurableDomains-Tuning.xml
+
+PFW_EDD_FILES := \
+    $(LOCAL_PATH)/$(LOCAL_MODULE_RELATIVE_PATH)/routing_cx20724.pfw \
+    $(LOCAL_PATH)/$(LOCAL_MODULE_RELATIVE_PATH)/routing_hdmi.pfw
+
+include $(BUILD_PFW_SETTINGS)
+
+###########################################
+# Audio PFW top file
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioParameterFramework.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework
+LOCAL_SRC_FILES := parameter-framework/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+###########################################
+
+###########################################
+# Audio PFW Structure files
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioClass.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := ConexantCX20724Subsystem.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := HdmiSubsystem.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+###########################################

--- a/common/audio/PCH-CX20724/parameter-framework/AudioCriteria.txt
+++ b/common/audio/PCH-CX20724/parameter-framework/AudioCriteria.txt
@@ -1,0 +1,7 @@
+ExclusiveCriterion  Mode                   :  Normal
+InclusiveCriterion  RoutageState           :  Configure   Flow          Path
+InclusiveCriterion  OpenedPlaybackRoutes   :  primary_output       hdmi_stereo     hdmi_multi
+InclusiveCriterion  OpenedCaptureRoutes    :  primary_input
+InclusiveCriterion  SelectedInputDevices   :  Headset Main
+InclusiveCriterion  SelectedOutputDevices  :  Headphones  Headset Ihf      AuxDigital 
+ExclusiveCriterion  ScreenState            :  Off         On

--- a/common/audio/PCH-CX20724/parameter-framework/AudioParameterFramework.xml
+++ b/common/audio/PCH-CX20724/parameter-framework/AudioParameterFramework.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ParameterFrameworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ParameterFrameworkConfiguration.xsd"
+    SystemClassName="Audio" ServerPort="5000" TuningAllowed="true">
+    <SubsystemPlugins>
+        <Location Folder="">
+            <Plugin Name="libtinyalsa-subsystem.so"/>
+        </Location>
+    </SubsystemPlugins>
+    <StructureDescriptionFileLocation Path="Structure/Audio/AudioClass.xml"/>
+    <SettingsConfiguration>
+        <ConfigurableDomainsFileLocation Path="Settings/Audio/AudioConfigurableDomains.xml"/>
+    </SettingsConfiguration>
+</ParameterFrameworkConfiguration>

--- a/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/AudioConfigurableDomains-Tuning.xml
+++ b/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/AudioConfigurableDomains-Tuning.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConfigurableDomains xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ConfigurableDomains.xsd" SystemClassName="Audio">
+    <ConfigurableDomain Name="OutputDevice.Selected" SequenceAware="false">
+	<Configurations>
+	    <Configuration Name="Multimedia.Master">
+		<CompoundRule Type="Any">
+		    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Headset"/>
+		    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Headphones"/>
+		    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Ihf"/>
+		</CompoundRule>
+	    </Configuration>
+	    <Configuration Name="Multimedia.Headset">
+	    	<CompoundRule Type="Any">
+	    	    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Headset"/>
+	    	    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Headphones"/>
+	    	</CompoundRule>
+	    </Configuration>
+	    <Configuration Name="Multimedia.Speaker">
+		<CompoundRule Type="Any">
+		    <SelectionCriterionRule SelectionCriterion="SelectedOutputDevices" MatchesWhen="Includes" Value="Ihf"/>
+		</CompoundRule>
+	    </Configuration>
+	</Configurations>
+	<ConfigurableElements>
+	    <ConfigurableElement Path="/Audio/cx20724/output/volume"/>
+	    <ConfigurableElement Path="/Audio/cx20724/output/headset/volume"/>
+	    <ConfigurableElement Path="/Audio/cx20724/output/speaker/volume"/>
+	</ConfigurableElements>
+	<Settings>
+	    <Configuration Name="Multimedia.Master">
+		<ConfigurableElement Path="/Audio/cx20724/output/volume">
+		    <IntegerParameter Name="volume">74</IntegerParameter>
+		</ConfigurableElement>
+	    </Configuration>
+	    <Configuration Name="Multimedia.Headset">
+	    	<ConfigurableElement Path="/Audio/cx20724/output/headset/volume">
+	    	    <IntegerParameter Name="volume">74 74</IntegerParameter>
+	    	</ConfigurableElement>
+	    </Configuration>
+	    <Configuration Name="Multimedia.Speaker">
+		<ConfigurableElement Path="/Audio/cx20724/output/speaker/volume">
+		    <IntegerParameter Name="volume">74 74</IntegerParameter>
+		</ConfigurableElement>
+	    </Configuration>
+	</Settings>
+    </ConfigurableDomain>
+
+    <ConfigurableDomain Name="InputDevice.Selected" SequenceAware="false">
+	<Configurations>
+	    <Configuration Name="Multimedia.Master">
+		<CompoundRule Type="Any">
+		    <SelectionCriterionRule SelectionCriterion="SelectedInputDevices" MatchesWhen="Includes" Value="Headset"/>
+		    <SelectionCriterionRule SelectionCriterion="SelectedInputDevices" MatchesWhen="Includes" Value="Main"/>
+		</CompoundRule>
+	    </Configuration>
+	</Configurations>
+	<ConfigurableElements>
+	    <ConfigurableElement Path="/Audio/cx20724/input/mic_headset/volume"/>
+	</ConfigurableElements>
+	<Settings>
+	    <Configuration Name="Multimedia.Master">
+		<ConfigurableElement Path="/Audio/cx20724/input/mic_headset/volume">
+		    <IntegerParameter Name="volume">74 74</IntegerParameter>
+		</ConfigurableElement>
+	    </Configuration>
+	</Settings>
+    </ConfigurableDomain>
+
+</ConfigurableDomains>

--- a/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/routing_cx20724.pfw
+++ b/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/routing_cx20724.pfw
@@ -1,0 +1,60 @@
+domainGroup: Routing.Cx20724
+
+	#########################################
+	############## Mute/unmute ##############
+	#########################################
+
+	domainGroup: flow
+		RoutageState Includes Flow
+
+		domainGroup: Playback
+			domainGroup: Media
+				confType: UnMute
+					ALL
+						OpenedPlaybackRoutes Includes primary_output
+
+				domain: Headset
+					conf: UnMute
+						ANY
+							SelectedOutputDevices Includes Headset
+							SelectedOutputDevices Includes Headphones
+						/Audio/cx20724/output/headset/switch = 1 1
+
+					conf: Mute
+						/Audio/cx20724/output/headset/switch = 0 0
+
+				domain: Speaker
+					conf: UnMute
+						ANY
+							SelectedOutputDevices Includes Ihf
+						/Audio/cx20724/output/speaker/switch = 1 1
+
+					conf: Mute
+						/Audio/cx20724/output/speaker/switch = 0 0
+
+				domain: Master
+					conf: UnMute
+						ANY
+							SelectedOutputDevices Includes Headset
+							SelectedOutputDevices Includes Headphones
+							SelectedOutputDevices Includes Ihf
+						/Audio/cx20724/output/switch = 1
+						
+					conf: Mute
+						/Audio/cx20724/output/switch = 0
+
+		domainGroup: Capture
+			domainGroup: Media
+				confType: UnMute
+					ANY
+						OpenedCaptureRoutes Includes primary_input
+
+				domain: Master
+					conf: UnMute
+						ANY
+							SelectedInputDevices Includes Headset
+							SelectedInputDevices Includes Main
+						/Audio/cx20724/input/mic_headset/switch = 1 1
+					conf: Mute
+						/Audio/cx20724/input/mic_headset/switch = 0 0
+

--- a/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/routing_hdmi.pfw
+++ b/common/audio/PCH-CX20724/parameter-framework/Settings/Audio/routing_hdmi.pfw
@@ -1,0 +1,22 @@
+domainGroup: Routing.Hdmi
+
+	#########################################
+	############### Configure ###############
+	#########################################
+
+	domainGroup: Configure
+		RoutageState Includes Configure
+
+		domainGroup: Playack
+			domain: Port0
+				conf: Bind
+					ALL
+						ANY
+							OpenedPlaybackRoutes Includes hdmi_stereo
+							OpenedPlaybackRoutes Includes hdmi_multi
+						SelectedOutputDevices Includes AuxDigital
+					/Audio/hdmi/output/port0/switch = 1
+
+				conf: Unbind
+					/Audio/hdmi/output/port0/switch = 0
+

--- a/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/AudioClass.xml
+++ b/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/AudioClass.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/SystemClass.xsd" Name="Audio">
+    <SubsystemInclude Path="ConexantCX20724Subsystem.xml"/>
+    <SubsystemInclude Path="HdmiSubsystem.xml"/>
+</SystemClass>
+

--- a/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/ConexantCX20724Subsystem.xml
+++ b/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/ConexantCX20724Subsystem.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="cx20724" Type="ALSA"
+    Mapping="Card:PCH,Debug">
+
+    <!--
+	The structure of the audio codec is as follows
+    /Audio/cx20724/output/
+                          switch
+                          volume
+                          headset/
+                                  switch
+                                  volume
+                          speaker/
+                                  switch
+                                  volume
+    /Audio/cx20724/input/
+                         switch
+                         volume
+
+    The component names can be arbitrary, they will be mapped in the tuning
+    files
+    
+    The order of the declarations does matter, the types need to be defined
+    before being instanciated and the file is organized from leaf nodes
+    to root. In this example, there are separate volumes for speaker and
+    headset but they use a common master volume. For the time being the
+    "Internal Mic Boost Volume" and "Mic Boost Volume" are not used
+    
+    The syntax Amend:string along with the %n notation is a replace operation
+    to avoid duplication
+    The ArrayLength is linked to the number of elements of the control,
+    it can be omitted when there is a single value. The Size is an internal
+    parameter framework representation but needs to be able to store the
+    largest control value.
+    -->
+    
+    <ComponentLibrary>
+        <!-- Outputs -->
+        <ComponentType Name="StereoOutputNode">
+            <BooleanParameter Name="switch" ArrayLength="2" Mapping="Control:'%1 Playback Switch'"/>
+            <IntegerParameter Name="volume" Size="8" Signed="false" Min="0" Max="74" ArrayLength="2" Mapping="Control:'%1 Playback Volume'"/>
+        </ComponentType>
+        <ComponentType Name="OutputNodes">
+            <Component Name="headset" Type="StereoOutputNode" Mapping="Amend1:Headphone"/>
+	    <Component Name="speaker" Type="StereoOutputNode" Mapping="Amend1:Speaker"/>
+            <BooleanParameter Name="switch" Mapping="Control:'Master Playback Switch'"/>
+            <IntegerParameter Name="volume" Size="8" Signed="false" Min="0" Max="74" Mapping="Control:'Master Playback Volume'"/>
+        </ComponentType>
+        <!-- Inputs -->
+        <ComponentType Name="CaptureNode">
+            <BooleanParameter Name="switch" ArrayLength="2" Mapping="Control:'Capture Switch'"/>
+            <IntegerParameter Name="volume" Size="8" Signed="false" Min="0" Max="80" ArrayLength="2" Mapping="Control:'Capture Volume'"/>
+        </ComponentType>
+        <ComponentType Name="InputNodes">
+            <Component Name="mic_headset" Type="CaptureNode"/>
+        </ComponentType>
+    </ComponentLibrary>
+
+    <InstanceDefinition>
+        <Component Name="output" Type="OutputNodes"/>
+        <Component Name="input" Type="InputNodes"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/HdmiSubsystem.xml
+++ b/common/audio/PCH-CX20724/parameter-framework/Structure/Audio/HdmiSubsystem.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="hdmi" Type="ALSA"
+    Mapping="Card:PCH,Debug">
+
+   <ComponentLibrary>
+        <!-- Outputs -->
+        <ComponentType Name="HdmiNode">
+            <BooleanParameter Name="switch" Mapping="Control:'IEC958 Playback Switch'"/>
+        </ComponentType>
+
+        <ComponentType Name="OutputNode">
+            <Component Name="port0" Type="HdmiNode"/>
+        </ComponentType>
+   </ComponentLibrary>
+
+    <InstanceDefinition>
+        <Component Name="output" Type="OutputNode"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/common/audio/PCH-CX20724/policy/audio_policy_configuration.xml
+++ b/common/audio/PCH-CX20724/policy/audio_policy_configuration.xml
@@ -15,29 +15,6 @@
 -->
 
 <audioPolicyConfiguration version="1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <!-- version section contains a “version” tag in the form “major.minor” e.g version=”1.0” -->
-
-    <!-- Modules section:
-        There is one section per audio HW module present on the platform.
-        Each module section will contains two mandatory tags for audio HAL “halVersion” and “name”.
-        The module names are the same as in current .conf file:
-                “primary”, “A2DP”, “remote_submix”, “USB”
-        Each module will contain the following sections:
-        “devicePorts”: a list of device descriptors for all input and output devices accessible via this
-        module.
-        This contains both permanently attached devices and removable devices.
-        “mixPorts”: listing all output and input streams exposed by the audio HAL
-        “routes”: list of possible connections between input and output devices or between stream and
-        devices.
-            "route": is defined by an attribute:
-                -"type": <mux|mix> means all sources are mutual exclusive (mux) or can be mixed (mix)
-                -"sink": the sink involved in this route
-                -"sources": all the sources than can be connected to the sink via vis route
-        “attachedDevices”: permanently attached devices.
-        The attachedDevices section is a list of devices names. The names correspond to device names
-        defined in <devicePorts> section.
-        “defaultOutputDevice”: device to be used by default when no policy rule applies
-    -->
     <modules>
         <!-- Primary Audio HAL -->
         <module name="primary" halVersion="3.0">
@@ -47,16 +24,42 @@
             </attachedDevices>
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
-                <mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY">
+                <mixPort name="primary_output" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY"
+                         card="PCH" device="0"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="2"
+                         startThreshold="239" stopThreshold="480" silenceThreshold="0" availMin="240">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
-                <mixPort name="primary input" role="sink">
+                <mixPort name="hdmi_stereo" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY"
+                         card="PCH" device="3"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="2"
+                         startThreshold="239" stopThreshold="480" silenceThreshold="0" availMin="240">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                </mixPort>
+                <mixPort name="hdmi_multi" role="source" flags="AUDIO_OUTPUT_FLAG_DIRECT"
+                         card="PCH" device="3"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="4"
+                         startThreshold="239" stopThreshold="960" silenceThreshold="0" availMin="240">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000"/>
+                </mixPort>
+                <mixPort name="primary_input" role="sink" flags="AUDIO_INPUT_FLAG_PRIMARY"
+                         card="PCH" device="0"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="2"
+                         startThreshold="1" stopThreshold="480" silenceThreshold="0" availMin="240"
+                         supportedUseCases="AUDIO_SOURCE_MIC,AUDIO_SOURCE_VOICE_COMMUNICATION,AUDIO_SOURCE_CAMCORDER,AUDIO_SOURCE_VOICE_RECOGNITION,AUDIO_SOURCE_HOTWORD">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000"
                              channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
                 </mixPort>
             </mixPorts>
+
             <devicePorts>
                 <!-- Output devices declaration, i.e. Sink DEVICE PORT -->
                 <devicePort tagName="Speaker" type="AUDIO_DEVICE_OUT_SPEAKER" role="sink">
@@ -83,17 +86,27 @@
                              channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
                 </devicePort>
 
+                <devicePort tagName="HDMI" type="AUDIO_DEVICE_OUT_HDMI" role="sink">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="32000,44100,48000"/>
+                </devicePort>
             </devicePorts>
             <!-- route declaration, i.e. list all available sources for a given sink -->
             <routes>
-                <route type="mix" sink="Speaker"
-                       sources="primary output"/>
                 <route type="mix" sink="Wired Headset"
-                       sources="primary output"/>
+                       sources="primary_output"/>
                 <route type="mix" sink="Wired Headphones"
-                       sources="primary output"/>
-                <route type="mix" sink="primary input"
-                       sources="Built-In Mic,Wired Headset Mic"/>
+                       sources="primary_output"/>
+		<route type="mix" sink="Speaker"
+                       sources="primary_output"/>
+		
+                 <route type="mix" sink="HDMI"
+			sources="hdmi_stereo,hdmi_multi"/>
+		 
+		 <route type="mix" sink="primary_input"
+                       sources="Wired Headset Mic,Built-In Mic"/>
             </routes>
 
         </module>
@@ -116,5 +129,10 @@
     <xi:include href="default_volume_tables.xml"/>
 
     <!-- End of Volume section -->
+
+    <!--Audio HAL Custom section -->
+    <xi:include href="audio_criteria.xml"/>
+    <xi:include href="audio_criterion_types.xml"/>
+    <!--End of Audio HAL Custom section -->
 
 </audioPolicyConfiguration>

--- a/common/audio/default/AndroidBoard.mk
+++ b/common/audio/default/AndroidBoard.mk
@@ -1,0 +1,88 @@
+LOCAL_PATH := $(call my-dir)
+PFW_CORE := external/parameter-framework
+BUILD_PFW_SETTINGS := $(PFW_CORE)/support/android/build_pfw_settings.mk
+PFW_DEFAULT_SCHEMAS_DIR := $(PFW_CORE)/upstream/schemas
+PFW_SCHEMAS_DIR := $(PFW_DEFAULT_SCHEMAS_DIR)
+
+###########################################
+# Audio stack Package
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := audio_parameter_framework
+LOCAL_MODULE_TAGS := optional
+LOCAL_REQUIRED_MODULES := \
+    libremote-processor \
+    remote-process \
+    AudioConfigurableDomains.xml
+
+include $(BUILD_PHONY_PACKAGE)
+
+###########################################
+# Audio PFW Package
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioConfigurableDomains.xml
+LOCAL_MODULES_TAGS := optional
+LOCAL_ADDITIONAL_DEPENDENCIES := \
+    AudioParameterFramework.xml \
+    AudioClass.xml \
+    DefaultHDaudioSubsystem.xml \
+    HdmiSubsystem.xml
+
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Settings/Audio
+LOCAL_REQUIRED_MODULES := \
+    libtinyalsa-subsystem
+
+PFW_TOPLEVEL_FILE := $(TARGET_OUT_ETC)/parameter-framework/AudioParameterFramework.xml
+PFW_CRITERIA_FILE := $(LOCAL_PATH)/parameter-framework/AudioCriteria.txt
+
+PFW_EDD_FILES := \
+    $(LOCAL_PATH)/$(LOCAL_MODULE_RELATIVE_PATH)/routing_defaulthda.pfw \
+    $(LOCAL_PATH)/$(LOCAL_MODULE_RELATIVE_PATH)/routing_hdmi.pfw
+
+include $(BUILD_PFW_SETTINGS)
+
+###########################################
+# Audio PFW top file
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioParameterFramework.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework
+LOCAL_SRC_FILES := parameter-framework/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+###########################################
+
+###########################################
+# Audio PFW Structure files
+###########################################
+include $(CLEAR_VARS)
+LOCAL_MODULE := AudioClass.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := DefaultHDaudioSubsystem.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := HdmiSubsystem.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_RELATIVE_PATH := parameter-framework/Structure/Audio
+LOCAL_SRC_FILES := $(LOCAL_MODULE_RELATIVE_PATH)/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+###########################################

--- a/common/audio/default/parameter-framework/AudioCriteria.txt
+++ b/common/audio/default/parameter-framework/AudioCriteria.txt
@@ -1,0 +1,7 @@
+ExclusiveCriterion  Mode                   :  Normal
+InclusiveCriterion  RoutageState           :  Configure   Flow          Path
+InclusiveCriterion  OpenedPlaybackRoutes   :  primary_output       hdmi_stereo     hdmi_multi
+InclusiveCriterion  OpenedCaptureRoutes    :  primary_input
+InclusiveCriterion  SelectedInputDevices   :  Headset Main
+InclusiveCriterion  SelectedOutputDevices  :  Headphones  Headset Ihf      AuxDigital 
+ExclusiveCriterion  ScreenState            :  Off         On

--- a/common/audio/default/parameter-framework/AudioParameterFramework.xml
+++ b/common/audio/default/parameter-framework/AudioParameterFramework.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ParameterFrameworkConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Schemas/ParameterFrameworkConfiguration.xsd"
+    SystemClassName="Audio" ServerPort="5000" TuningAllowed="true">
+    <SubsystemPlugins>
+        <Location Folder="">
+            <Plugin Name="libtinyalsa-subsystem.so"/>
+        </Location>
+    </SubsystemPlugins>
+    <StructureDescriptionFileLocation Path="Structure/Audio/AudioClass.xml"/>
+    <SettingsConfiguration>
+        <ConfigurableDomainsFileLocation Path="Settings/Audio/AudioConfigurableDomains.xml"/>
+    </SettingsConfiguration>
+</ParameterFrameworkConfiguration>

--- a/common/audio/default/parameter-framework/Settings/Audio/routing_defaulthda.pfw
+++ b/common/audio/default/parameter-framework/Settings/Audio/routing_defaulthda.pfw
@@ -1,0 +1,43 @@
+domainGroup: Routing.Defaulthda
+
+	#########################################
+	############## Mute/unmute ##############
+	#########################################
+
+	domainGroup: flow
+		RoutageState Includes Flow
+
+		domainGroup: Playback
+			domainGroup: Media
+				confType: UnMute
+					ALL
+						OpenedPlaybackRoutes Includes primary_output
+
+				domain: Master
+					conf: UnMute
+						ANY
+							SelectedOutputDevices Includes Headset
+							SelectedOutputDevices Includes Headphones
+							SelectedOutputDevices Includes Ihf
+						/Audio/defaulthda/output/switch = 1
+						/Audio/defaulthda/output/volume = 63
+						
+					conf: Mute
+						/Audio/defaulthda/output/switch = 0
+						/Audio/defaulthda/output/volume = 0
+
+		domainGroup: Capture
+			domainGroup: Media
+				confType: UnMute
+					ANY
+						OpenedCaptureRoutes Includes primary_input
+
+				domain: Master
+					conf: UnMute
+						ANY
+							SelectedInputDevices Includes Headset
+							SelectedInputDevices Includes Main
+						/Audio/defaulthda/input/mic_headset/switch = 1 1
+					conf: Mute
+						/Audio/defaulthda/input/mic_headset/switch = 0 0
+

--- a/common/audio/default/parameter-framework/Settings/Audio/routing_hdmi.pfw
+++ b/common/audio/default/parameter-framework/Settings/Audio/routing_hdmi.pfw
@@ -1,0 +1,22 @@
+domainGroup: Routing.Hdmi
+
+	#########################################
+	############### Configure ###############
+	#########################################
+
+	domainGroup: Configure
+		RoutageState Includes Configure
+
+		domainGroup: Playack
+			domain: Port0
+				conf: Bind
+					ALL
+						ANY
+							OpenedPlaybackRoutes Includes hdmi_stereo
+							OpenedPlaybackRoutes Includes hdmi_multi
+						SelectedOutputDevices Includes AuxDigital
+					/Audio/hdmi/output/port0/switch = 1
+
+				conf: Unbind
+					/Audio/hdmi/output/port0/switch = 0
+

--- a/common/audio/default/parameter-framework/Structure/Audio/AudioClass.xml
+++ b/common/audio/default/parameter-framework/Structure/Audio/AudioClass.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/SystemClass.xsd" Name="Audio">
+    <SubsystemInclude Path="DefaultHDaudioSubsystem.xml"/>
+    <SubsystemInclude Path="HdmiSubsystem.xml"/>
+</SystemClass>
+

--- a/common/audio/default/parameter-framework/Structure/Audio/DefaultHDaudioSubsystem.xml
+++ b/common/audio/default/parameter-framework/Structure/Audio/DefaultHDaudioSubsystem.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="defaulthda" Type="ALSA"
+    Mapping="Card:PCH,Debug">
+
+    <!--
+	The structure of the audio codec is as follows
+    /Audio/defaulthda/output/
+                          switch
+                          volume
+    /Audio/defaulthda/input/
+                         switch
+                         volume
+
+    The component names can be arbitrary, they will be mapped in the tuning
+    files
+    
+    The order of the declarations does matter, the types need to be defined
+    before being instanciated and the file is organized from leaf nodes
+    to root. In this example, there are separate volumes for speaker and
+    headset but they use a common master volume. For the time being the
+    "Internal Mic Boost Volume" and "Mic Boost Volume" are not used
+    
+    The syntax Amend:string along with the %n notation is a replace operation
+    to avoid duplication
+    The ArrayLength is linked to the number of elements of the control,
+    it can be omitted when there is a single value. The Size is an internal
+    parameter framework representation but needs to be able to store the
+    largest control value.
+    -->
+    
+    <ComponentLibrary>
+        <!-- Outputs -->
+        <ComponentType Name="OutputNodes">
+            <BooleanParameter Name="switch" Mapping="Control:'Master Playback Switch'"/>
+            <IntegerParameter Name="volume" Size="8" Signed="false" Min="0" Max="63" Mapping="Control:'Master Playback Volume'"/>
+        </ComponentType>
+        <!-- Inputs -->
+        <ComponentType Name="CaptureNode">
+            <BooleanParameter Name="switch" ArrayLength="2" Mapping="Control:'Capture Switch'"/>
+            <IntegerParameter Name="volume" Size="8" Signed="false" Min="0" Max="63" ArrayLength="2" Mapping="Control:'Capture Volume'"/>
+        </ComponentType>
+        <ComponentType Name="InputNodes">
+            <Component Name="mic_headset" Type="CaptureNode"/>
+        </ComponentType>
+    </ComponentLibrary>
+
+    <InstanceDefinition>
+        <Component Name="output" Type="OutputNodes"/>
+        <Component Name="input" Type="InputNodes"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/common/audio/default/parameter-framework/Structure/Audio/HdmiSubsystem.xml
+++ b/common/audio/default/parameter-framework/Structure/Audio/HdmiSubsystem.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subsystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:noNamespaceSchemaLocation="../../Schemas/Subsystem.xsd"
+    Name="hdmi" Type="ALSA"
+    Mapping="Card:PCH,Debug">
+
+   <ComponentLibrary>
+        <!-- Outputs -->
+        <ComponentType Name="HdmiNode">
+            <BooleanParameter Name="switch" Mapping="Control:'IEC958 Playback Switch'"/>
+        </ComponentType>
+
+        <ComponentType Name="OutputNode">
+            <Component Name="port0" Type="HdmiNode"/>
+        </ComponentType>
+   </ComponentLibrary>
+
+    <InstanceDefinition>
+        <Component Name="output" Type="OutputNode"/>
+    </InstanceDefinition>
+</Subsystem>

--- a/common/audio/default/policy/audio_policy_configuration.xml
+++ b/common/audio/default/policy/audio_policy_configuration.xml
@@ -32,7 +32,23 @@
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
-                <mixPort name="primary_input" role="sink"
+                <mixPort name="hdmi_stereo" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY"
+                         card="PCH" device="3"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="2"
+                         startThreshold="239" stopThreshold="480" silenceThreshold="0" availMin="240">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                </mixPort>
+                <mixPort name="hdmi_multi" role="source" flags="AUDIO_OUTPUT_FLAG_DIRECT"
+                         card="PCH" device="3"
+                         requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
+                         periodSize="240" periodCount="4"
+                         startThreshold="239" stopThreshold="960" silenceThreshold="0" availMin="240">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000"/>
+                </mixPort>
+                <mixPort name="primary_input" role="sink" flags="AUDIO_INPUT_FLAG_PRIMARY"
                          card="PCH" device="0"
                          requirePreEnable="0" requirePostDisable="0" silencePrologMs="0"
                          periodSize="240" periodCount="2"
@@ -43,6 +59,7 @@
                              channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
                 </mixPort>
             </mixPorts>
+
             <devicePorts>
                 <!-- Output devices declaration, i.e. Sink DEVICE PORT -->
                 <devicePort tagName="Speaker" type="AUDIO_DEVICE_OUT_SPEAKER" role="sink">
@@ -69,18 +86,27 @@
                              channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
                 </devicePort>
 
+                <devicePort tagName="HDMI" type="AUDIO_DEVICE_OUT_HDMI" role="sink">
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                             samplingRates="32000,44100,48000"/>
+                </devicePort>
             </devicePorts>
             <!-- route declaration, i.e. list all available sources for a given sink -->
             <routes>
-                <route type="mix" sink="Speaker"
-                       sources="primary_output"/>
                 <route type="mix" sink="Wired Headset"
                        sources="primary_output"/>
                 <route type="mix" sink="Wired Headphones"
                        sources="primary_output"/>
-
-                <route type="mix" sink="primary_input"
-                       sources="Built-In Mic,Wired Headset Mic"/>
+		<route type="mix" sink="Speaker"
+                       sources="primary_output"/>
+		
+                 <route type="mix" sink="HDMI"
+			sources="hdmi_stereo,hdmi_multi"/>
+		 
+		 <route type="mix" sink="primary_input"
+                       sources="Wired Headset Mic,Built-In Mic"/>
             </routes>
 
         </module>
@@ -103,5 +129,10 @@
     <xi:include href="default_volume_tables.xml"/>
 
     <!-- End of Volume section -->
+
+    <!--Audio HAL Custom section -->
+    <xi:include href="audio_criteria.xml"/>
+    <xi:include href="audio_criterion_types.xml"/>
+    <!--End of Audio HAL Custom section -->
 
 </audioPolicyConfiguration>


### PR DESCRIPTION
Add files for HP 2:1 and default HDaudio

The default HAL is still the baseline but this is the last step before switching HALs in Android-IA