### PR TITLE
Fix support for stub HAL

### DIFF
--- a/common/audio/AndroidBoard.mk
+++ b/common/audio/AndroidBoard.mk
@@ -15,6 +15,7 @@ AUDIO_HARDWARE := default
 # Next configuration is used for Intel NUC6i5SYH
 #AUDIO_HARDWARE := PCH-ALC283
 #AUDIO_HARDWARE := nuc-skull-canyon
+endif
 
 ###########################################
 # Audio stack Packages
@@ -26,8 +27,15 @@ LOCAL_REQUIRED_MODULES := \
     audio_policy_configuration_files \
     audio_settings_configuration_files
 
+ifeq ($(INTEL_AUDIO_HAL), stub)
+LOCAL_REQUIRED_MODULES += audio.stub.default
+else
+LOCAL_REQUIRED_MODULES += audio.primary.android_ia
+
 ifeq ($(INTEL_AUDIO_HAL),audio_pfw)
 LOCAL_REQUIRED_MODULES += audio_hal_configuration_files
+endif
+
 endif
 
 include $(BUILD_PHONY_PACKAGE)
@@ -45,6 +53,10 @@ LOCAL_REQUIRED_MODULES := \
     audio_policy_volumes.xml \
     default_volume_tables.xml \
     audio_policy_configuration.xml
+
+ifeq ($(INTEL_AUDIO_HAL), stub)
+LOCAL_REQUIRED_MODULES += stub_audio_policy_configuration.xml
+endif
 
 include $(BUILD_PHONY_PACKAGE)
 
@@ -86,6 +98,15 @@ include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := usb_audio_policy_configuration.xml
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)
+LOCAL_SRC_FILES := default/policy/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := stub_audio_policy_configuration.xml
 LOCAL_MODULE_OWNER := intel
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := ETC

--- a/common/audio/default/policy/stub_audio_policy_configuration.xml
+++ b/common/audio/default/policy/stub_audio_policy_configuration.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2017 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<!-- Stub Audio HAL Audio Policy Configuration file -->
+
+<module name="stub" halVersion="2.0">
+    <attachedDevices>
+        <item>Default Out</item>
+        <item>Default In</item>
+        </attachedDevices>
+    <defaultOutputDevice>Default Out</defaultOutputDevice>
+    <mixPorts>
+        <mixPort name="stub output" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="44100" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        </mixPort>
+
+        <mixPort name="stub input" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="44100" channelMasks="AUDIO_CHANNEL_IN_STEREO"/>
+        </mixPort>
+    </mixPorts>
+    <devicePorts>
+        <devicePort tagName="Default Out" type="AUDIO_DEVICE_OUT_STUB" role="sink">
+                </devicePort>
+
+        <devicePort tagName="Default In" type="AUDIO_DEVICE_IN_STUB" role="source">
+        </devicePort>
+    </devicePorts>
+    <routes>
+        <route type="mix" sink="Default Out" sources="stub output"/>
+
+        <route type="mix" sink="stub input" sources="Default In"/>
+    </routes>
+</module>


### PR DESCRIPTION
This patch adds xml config file for stub HAL and
fix the bug of lack of 'endif' in
common/audio/AndroidBoard.mk

Also the android.primary.android_ia or android.stub.primary
are handled are required dependencies as needed

Signed-off-by: Fuwei Tang <fuweix.tang@intel.com>
Signed-off-by: Libin Yang <libin.yang@intel.com>
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>