### PR TITLE
To fix the CTS issues filed for AAC-LC stereo encoding.

### DIFF
--- a/common/media/media_profiles.xml
+++ b/common/media/media_profiles.xml
@@ -453,9 +453,9 @@
         minChannels="1" maxChannels="1" />
 
     <AudioEncoderCap name="aac" enabled="true"
-        minBitRate="5525" maxBitRate="250000"
-        minSampleRate="8000" maxSampleRate="44100"
-        minChannels="1" maxChannels="1" />
+        minBitRate="32000" maxBitRate="320000"
+        minSampleRate="8000" maxSampleRate="48000"
+        minChannels="1" maxChannels="2" />
 
     <!--
         FIXME:


### PR DESCRIPTION
Changes added in media_profiles.xml to support stereo CTS cases for AAC-LC encoding.

JIRA: OAM-46784
Test: Have run related CTS cases for AAC-LC encoder