### PR TITLE
add debug log sepolicy permission to android ia code base

### DIFF
--- a/sepolicy/debug-logs/dumpstate.te
+++ b/sepolicy/debug-logs/dumpstate.te
@@ -1,0 +1,5 @@
+#
+# dumpstate
+#
+
+allow dumpstate log_file:file r_file_perms;

--- a/sepolicy/debug-logs/file.te
+++ b/sepolicy/debug-logs/file.te
@@ -1,0 +1,1 @@
+type log_file, mlstrustedobject, file_type;

--- a/sepolicy/debug-logs/file_contexts
+++ b/sepolicy/debug-logs/file_contexts
@@ -1,0 +1,14 @@
+# earlylogs entry point script
+(/system)?/vendor/bin/elogs.sh     u:object_r:logsvc_exec:s0
+
+(/system)?/vendor/bin/start_log_srv.sh  u:object_r:logsvc_exec:s0
+
+# ap[k]_logfs entry point script
+# this is also used by debug-npk, which is dependent on debug-logs
+(/system)?/vendor/bin/logcat_ep.sh      u:object_r:logsvc_exec:s0
+
+# earlylogs logs target
+/cache/elogs(/.*)?              u:object_r:log_file:s0
+
+# Logs
+/data/logs(/.*)?                u:object_r:log_file:s0

--- a/sepolicy/debug-logs/logsvc.te
+++ b/sepolicy/debug-logs/logsvc.te
@@ -1,0 +1,34 @@
+# Rules for debug-logs specific services
+type logsvc, domain;
+type logsvc_exec, exec_type, file_type;
+
+init_daemon_domain(logsvc);
+
+allow logsvc system_file:file x_file_perms;
+allow logsvc shell_exec:file rx_file_perms;
+
+allow logsvc self:capability { dac_override sys_nice };
+allow logsvc self:capability2 syslog;
+
+allow logsvc log_file:file create_file_perms;
+allow logsvc log_file:dir rw_dir_perms;
+
+allow logsvc logdr_socket:sock_file write;
+allow logsvc logd:unix_stream_socket connectto;
+
+allow logsvc kmsg_device:chr_file { open read };
+allow logsvc kernel:system syslog_read;
+
+set_prop(logsvc, system_prop)
+set_prop(logsvc, ctl_default_prop)
+
+allow logsvc logsvc_exec:file execute_no_trans;
+
+allow logsvc logcat_exec:file execute_no_trans;
+allow logsvc logcat_exec:file rx_file_perms;
+
+# Execute toolbox/toybox commands
+allow logsvc toolbox_exec:file rx_file_perms;
+ 
+allow logsvc cache_file:dir r_dir_perms;
+allow logsvc cache_file:file r_file_perms;

--- a/sepolicy/debug-logs/nfc.te
+++ b/sepolicy/debug-logs/nfc.te
@@ -1,0 +1,5 @@
+#
+# nfc
+#
+
+allow nfc log_file:file write;

--- a/sepolicy/debug-logs/system_app.te
+++ b/sepolicy/debug-logs/system_app.te
@@ -1,0 +1,7 @@
+#
+# system_app
+#
+
+allow system_app log_file:dir create_dir_perms;
+allow system_app log_file:file create_file_perms;
+allow system_app log_file:filesystem getattr;

--- a/sepolicy/debug-logs/vdc.te
+++ b/sepolicy/debug-logs/vdc.te
@@ -1,0 +1,2 @@
+allow vdc log_file:dir r_dir_perms;
+allow vdc log_file:file r_file_perms;


### PR DESCRIPTION
[Anroid-IA] add debug log sepolicy permission to android ia code base
make all crashlogs show up in /data/logs folder

JIRA : OAM-47124
TEST : passed on joule

Signed-off-by: baofeng, tian baofeng.tian@intel.com