### PR TITLE
Exports used by HWC-VAL code.

### DIFF
--- a/androidia_64/hwc-valsetup.sh
+++ b/androidia_64/hwc-valsetup.sh
@@ -1,0 +1,10 @@
+LOCAL_PATH="$(gettop)"
+HWCOMPOSER_PATH="$(find vendor -name hwcomposer)"
+export HWCVAL_ROOT=$LOCAL_PATH/$HWCOMPOSER_PATH/tests/hwc-val/tests/hwc
+export VAL_HWC_TOP="`( cd "$HWCVAL_ROOT/../.." && pwd)`"
+export PATH=$HWCVAL_ROOT/host_scripts:$HWCVAL_ROOT/tools:$PATH
+export CLIENT_LOGS=$HOME/client_logs
+
+# Target directories
+export HWCVAL_TARGET_DIR=/data/validation/hwc
+export HWCVAL_TARGET_SCRIPT_DIR=/data/validation/hwc

--- a/androidia_64/vendorsetup.sh
+++ b/androidia_64/vendorsetup.sh
@@ -1,3 +1,6 @@
 add_lunch_combo androidia_64-eng
 add_lunch_combo androidia_64-userdebug
 add_lunch_combo androidia_64-user
+
+
+. $('gettop')/device/intel/android_ia/androidia_64/hwc-valsetup.sh


### PR DESCRIPTION
Patch exports environment variables required for HWC Validation.
JIRA:None
Tests:compilation and execution of hwcomposer/hwc-val works fine.
Signed-off-by:Munish Bhardwaj<munishx.bhardwaj@intel.com>