### PR TITLE
Add memtrack to mixin.spec

### DIFF
--- a/androidia_64/mixins.spec
+++ b/androidia_64/mixins.spec
@@ -42,3 +42,4 @@ midi: true
 slcan: default
 ioc-slcan-reboot: false
 camera: usbcamera
+memtrack: true


### PR DESCRIPTION
Jira: None
Test: memtrack libraries should be present in vendor partition

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>