### PR TITLE
Fix sepolicy errors when building system image

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,20 @@
+# USB Gadget Serial Devices
+/dev/ttyGS[0-9]*            u:object_r:serial_device:s0
+
+# Marvell wifi device socket
+/dev/socket/wpa_mlan[0-9] u:object_r:wpa_socket:s0
+
+# slot-ab with ext4
+/file_contexts.bin           u:object_r:rootfs:s0
+/fstab                       u:object_r:rootfs:s0
+/hwc.lock                    u:object_r:rootfs:s0
+/ioc-slcan-reboot-timestamp  u:object_r:rootfs:s0
+/metadata                    u:object_r:rootfs:s0
+/oem_config                  u:object_r:config_file:s0
+/preload_module              u:object_r:rootfs:s0
+/splash                      u:object_r:rootfs:s0
+/misc                        u:object_r:rootfs:s0
+/splash/splash.png           u:object_r:rootfs:s0
+/boot                        u:object_r:rootfs:s0
+/gpt.androidia_64.ini        u:object_r:rootfs:s0
+/persistent                  u:object_r:rootfs:s0


### PR DESCRIPTION
When enable avb, it fails to build system image. There is errors:
build_directory_structure: cannot lookup security context for /xxx.

Jira: None.
Test: Test it on Joule and KBL NUC.

Signed-off-by: Zhou, Lihua <lihuax.zhou@intel.com>