### PR TITLE
[PATCH] Set the sepolicy configuration of directorys in root directory.

### DIFF
--- a/sepolicy/boot-arch/android_ia/file_contexts
+++ b/sepolicy/boot-arch/android_ia/file_contexts
@@ -9,3 +9,11 @@
 /dev/block/(pci|platform)(/.*)?/.*/by-name/android_cache      u:object_r:cache_block_device:s0
 /dev/block/(pci|platform)(/.*)?/.*/by-name/android_data       u:object_r:userdata_block_device:s0
 /dev/block/(pci|platform)(/.*)?/.*/by-name/android_misc       u:object_r:misc_block_device:s0
+
+/file_contexts.bin           u:object_r:rootfs:s0
+/metadata                    u:object_r:rootfs:s0
+/misc                        u:object_r:rootfs:s0
+/boot                        u:object_r:rootfs:s0
+/gpt.androidia_64.ini        u:object_r:rootfs:s0
+/persistent                  u:object_r:rootfs:s0
+/tos                         u:object_r:rootfs:s0


### PR DESCRIPTION
It is needed for build the system.img after enable AVB and A/B slot.

Jira: None.
Test: Test it in Joule and KBL NUC using kernelflinger.

Signed-off-by: Zhou, Lihua <lihuax.zhou@intel.com>
Signed-off-by: Ming Tan <ming.tan@intel.com>