### PR TITLE
Makes search for hardware composer generic.

### DIFF
--- a/androidia_64/hwc-valsetup.sh
+++ b/androidia_64/hwc-valsetup.sh
@@ -1,5 +1,5 @@
 LOCAL_PATH="$(gettop)"
-HWCOMPOSER_PATH="$(find vendor -name hwcomposer)"
+HWCOMPOSER_PATH="$(find vendor -name hwcomposer*)"
 export HWCVAL_ROOT=$LOCAL_PATH/$HWCOMPOSER_PATH/tests/hwc-val/tests/hwc
 export VAL_HWC_TOP="`( cd "$HWCVAL_ROOT/../.." && pwd)`"
 export PATH=$HWCVAL_ROOT/host_scripts:$HWCVAL_ROOT/tools:$PATH


### PR DESCRIPTION
Patch lets search for hwcomposer also work with postfix. Path is used for exports
required for HWC Validation.

JIRA:None
Tests:compilation of hwcomposer validation works fine.

Signed-off-by:Munish Bhardwaj<munishx.bhardwaj@intel.com>