### PR TITLE
Config default wallpaper picker package to com.android.wallpaperpicker

### DIFF
--- a/common/overlay/packages/apps/Launcher3/res/values/config.xml
+++ b/common/overlay/packages/apps/Launcher3/res/values/config.xml
@@ -1,0 +1,4 @@
+<resources>
+    <!-- Package name of the default wallpaper picker. -->
+    <string name="wallpaper_picker_package" translatable="false">com.android.wallpaperpicker</string>
+</resources>


### PR DESCRIPTION
Nexus6P and Google emulator all of them are config defalut wallpaper,
it can improve user experience, and avoid to the end user set the live
wallpaper picker as default application.

Due to the AOSP wallpaperpicker not only set wallpaper but also can set
the live wallpaper. So, select the AOSP wallpaperpicker as default is the
best choice.

JIRA:None
Tests:Long press home screen, click wallpaper, don't pop up menu.

Signed-off-by: Yue, VincentX <vincentx.yue@intel.com>